### PR TITLE
Remove deprecated clone() method in BehaviorCall

### DIFF
--- a/retrofit-mock/src/main/java/retrofit2/mock/BehaviorCall.java
+++ b/retrofit-mock/src/main/java/retrofit2/mock/BehaviorCall.java
@@ -48,10 +48,10 @@ final class BehaviorCall<T> implements Call<T> {
   }
 
   @SuppressWarnings("CloneDoesntCallSuperClone") // We are a final type & this saves clearing state.
-  @Override
-  public Call<T> clone() {
+  public BehaviorCall<T> copy() {
     return new BehaviorCall<>(behavior, backgroundExecutor, delegate.clone());
   }
+
 
   @Override
   public Request request() {


### PR DESCRIPTION
This change removes the clone() method from BehaviorCall to comply with SonarQube’s recommendation to avoid overriding clone(). The class now relies on constructor-based object creation for safer duplication.
Done by:
Name :- Dev Patel
ID:- 40305577