### PR TITLE
Fix #1 - Add explanatory comment for intentionally empty method

### DIFF
--- a/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RecordingCompletableObserver.java
+++ b/retrofit-adapters/rxjava2/src/test/java/retrofit2/adapter/rxjava2/RecordingCompletableObserver.java
@@ -36,7 +36,10 @@ final class RecordingCompletableObserver implements CompletableObserver {
   private RecordingCompletableObserver() {}
 
   @Override
-  public void onSubscribe(Disposable disposable) {}
+  public void onSubscribe(Disposable disposable) {
+    // No-op: This test observer does not track the Disposable subscription,
+    // as it only records completion and error events for verification purposes.
+  }
 
   @Override
   public void onComplete() {
@@ -59,16 +62,16 @@ final class RecordingCompletableObserver implements CompletableObserver {
   public Throwable takeError() {
     Notification<?> notification = takeNotification();
     assertWithMessage("Expected onError event but was " + notification)
-        .that(notification.isOnError())
-        .isTrue();
+      .that(notification.isOnError())
+      .isTrue();
     return notification.getError();
   }
 
   public void assertComplete() {
     Notification<?> notification = takeNotification();
     assertWithMessage("Expected onCompleted event but was " + notification)
-        .that(notification.isOnComplete())
-        .isTrue();
+      .that(notification.isOnComplete())
+      .isTrue();
     assertNoEvents();
   }
 


### PR DESCRIPTION
onSubscribe(……) method (java:S1186)

SonarQube reported a code smell (rule java:S1186 - 'Methods should not be empty') in RecordingCompletableObserver.java at line 39.

The onSubscribe(Disposable) method is intentionally left empty because this test observer does not track the Disposable subscription. It only records completion and error events for verification purposes. Added a clear explanatory comment to make this intent explicit and remove the SonarQube warning.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
